### PR TITLE
Fix match indexing in phone search

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -322,8 +322,8 @@ export const findNumbersInString = (text) => {
     if (
       number.replace(new RegExp(`[${VALID_PUNCTUATION}]`, 'g'), '').length >= 6
     ) {
-      const index = text.indexOf(number);
-      const lastIndex = index + number.length;
+      const index = match.index;
+      const lastIndex = regex.lastIndex;
       const phoneParts = getPhoneParts(number);
 
       // Presumed phone numbers may be invalidated by omission of formattedNumber from getPhoneParts.


### PR DESCRIPTION
## Summary
- avoid rescanning the input when extracting phone numbers
- use regex match index and lastIndex directly

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a463de00833398f6cd68ec23e341